### PR TITLE
update javascript flake, better organize exports

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -5,29 +5,31 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1714602819,
-        "narHash": "sha256-U/emV+rC0ssCNvOdlKRt4K9AUzrQcGW3PzvD6E/NNKg=",
+        "lastModified": 1714776728,
+        "narHash": "sha256-Hs7WOGPk4Kolg4pPTihPGGPOAfCl6+As67pDJkOb/DM=",
         "owner": "auxolotl",
-        "repo": "packages",
-        "rev": "48b022083ffb6e2f1dbfec08411a08f63149b8a0",
+        "repo": "core",
+        "rev": "cbe7a41cc89ccda6bfd14da7c2a8cf982ca07d24",
         "type": "github"
       },
       "original": {
         "owner": "auxolotl",
-        "repo": "packages",
+        "repo": "core",
         "type": "github"
       }
     },
     "javascript": {
       "inputs": {
-        "top-level": []
+        "core": [
+          "core"
+        ]
       },
       "locked": {
-        "lastModified": 1714721665,
-        "narHash": "sha256-mKYBnQ7XKe5cabtVB4gkhhS0LCjRt+TO38szsedukJE=",
+        "lastModified": 1714958271,
+        "narHash": "sha256-uqd06kP5le/phhPeTKrLN61i6WAgi1qyIByiVTbSZB4=",
         "owner": "auxolotl",
         "repo": "javascript",
-        "rev": "36ef70c8a6b958878077e785a6da57246dd03330",
+        "rev": "bcba61388e79647b63f4ad6086b14ab1ccb4a517",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,10 +1,10 @@
 {
   inputs = {
-    core.url = "github:auxolotl/packages";
+    core.url = "github:auxolotl/core";
 
     javascript = {
       url = "github:auxolotl/javascript";
-      inputs.top-level.follows = "";
+      inputs.core.follows = "core";
     };
   };
 
@@ -26,15 +26,16 @@
         );
     in
     {
-      inherit (core) lib;
+      inherit (core) lib nixPackages;
 
       auxPackages = forAllSystems (
-        { auxPackages, nixPackages, ... }:
+        { nixPackages, ... }:
         let
           inherit (nixPackages.stdenv.hostPlatform) system;
         in
         {
-          core = auxPackages;
+          # TODO: uncomment when core exposes auxPackages
+          # core = auxPackages;
           javascript = javascript.packages.${system};
         }
       );


### PR DESCRIPTION
see https://github.com/auxolotl/javascript/pull/1 for background (this also depends on it)

in addition to making top-level compatible with that PR, this also improves the usability of the actual exports. currently, each external flake (though there is only one) is instantiated without a `system` which would pass that responsibility down to the caller. this is not very user friendly as unlike nixpkgs, we will have multiple sets of packages here (i.e., instead of just `legacyPackages.${system}`, we also have to worry about getting `javascript.packages.${system}`, `go.packages.${system}`, etc.)

i propose we have another set of `auxPackages` similar to `core` that is an attribute set of each flake and their packages. the idea is for it to be used like so
```nix
{
  inputs.auxpkgs.url = "github:auxolotl/top-level";
  
  outputs = { auxpkgs, ... }: let
    forAllSystems = fn: 
      auxpkgs.lib.genAttrs
      auxpkgs.lib.flakeExposed
      (system: fn auxpkgs.auxPackages.${system});
  in {
    packages = forAllSystems (pkgs: {
      inherit (pkgs.core) hello;
      inherit (pkgs.javascript) prettier;
      inherit (pkgs.rust) ripgrep;
    });
  };
}
```

lastly, some outputs from core are directly re-exported such as `lib` and `nixPackages`